### PR TITLE
Fix CLI tests to use sys.executable

### DIFF
--- a/tests/test_kfe_codec.py
+++ b/tests/test_kfe_codec.py
@@ -43,8 +43,8 @@ def test_cli():
         dst = os.path.join(tmp, 'd.bin')
         with open(src, 'wb') as f:
             f.write(data)
-        subprocess.check_call(['python', 'kfe_codec.py', 'encode', src, enc])
-        subprocess.check_call(['python', 'kfe_codec.py', 'decode', enc, dst])
+        subprocess.check_call([sys.executable, 'kfe_codec.py', 'encode', src, enc])
+        subprocess.check_call([sys.executable, 'kfe_codec.py', 'decode', enc, dst])
         with open(dst, 'rb') as f:
             assert f.read() == data
 


### PR DESCRIPTION
## Summary
- ensure the CLI tests run with the interpreter used for pytest

## Testing
- `pytest -q`