### PR TITLE
Add HDMI loopback CLI with metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ compression or encryption is applied.
 
 ## Usage
 
-The command line interface supports four operations: `encode`, `decode`,
-`capture` and `display`.
+The command line interface supports several operations: `encode`, `decode`,
+`capture`, `display` and `loopback`.
 
 ```bash
 # Encode a binary file to the custom .kfe container
@@ -34,6 +34,9 @@ python kfe_codec.py capture capture.kfe --device 0 --frames 60
 
 # Display a container in a window or write it to a video file
 python kfe_codec.py display capture.kfe --fps 30
+
+# Forward network packets through HDMI loopback using tun0
+python kfe_codec.py loopback --tun tun0 --device 0 --packets 100
 ```
 
 Use the `-v` option for verbose logging.
@@ -54,3 +57,48 @@ for both small and multi-frame inputs.
 The CLI relies on `opencv-python` and `numpy` for capture and display
 functionality. These packages are not required for basic encoding/decoding but
 must be installed to use the `capture` or `display` commands.
+
+## Loopback demonstration
+
+The `kfe_loopback` module provides helper functions for packing network
+packets into KFE frames. It also contains a simple `run_loopback()` routine
+that demonstrates how a TUN interface can be bridged through an HDMI capture
+device. The function requires root privileges to create/attach to the TUN
+interface and an accessible video capture device.
+
+### Preparing a TUN interface
+
+On Linux the following commands create a TUN device named ``tun0`` and assign
+an address to it (root privileges required):
+
+```bash
+sudo ip tuntap add dev tun0 mode tun
+sudo ip addr add 10.0.0.1/24 dev tun0
+sudo ip link set tun0 up
+```
+
+After the interface is created, packets sent to ``tun0`` can be forwarded
+through the HDMI loopback using either the Python API above or the CLI
+command. The loopback routine prints measured round-trip time (RTT) and
+throughput statistics after processing the requested number of packets:
+
+```bash
+python kfe_codec.py loopback --tun tun0 --device 0 --packets 100
+```
+
+```python
+from kfe_loopback import run_loopback
+
+# Forward up to 100 packets through HDMI using tun0 and device 0
+run_loopback(tun="tun0", device=0, packets=100)
+```
+
+`packet_to_frame()` and `frame_to_packet()` can be used independently of the
+loopback demo:
+
+```python
+from kfe_loopback import packet_to_frame, frame_to_packet
+
+frame = packet_to_frame(b"demo packet")
+packet = frame_to_packet(frame)
+```

--- a/kfe_codec.py
+++ b/kfe_codec.py
@@ -196,6 +196,11 @@ def main(argv=None):
     disp.add_argument('--fps', type=int, default=30, help='Frames per second')
     disp.add_argument('--window', default='KFE Display', help='Display window name')
 
+    loop = subparsers.add_parser('loopback', help='Run HDMI loopback demo')
+    loop.add_argument('--tun', default='tun0', help='TUN interface name')
+    loop.add_argument('--device', type=int, default=0, help='Capture device ID')
+    loop.add_argument('--packets', type=int, default=100, help='Number of packets to process')
+
     parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose logging')
 
     args = parser.parse_args(argv)
@@ -209,6 +214,9 @@ def main(argv=None):
         capture(args.output, device=args.device, frames=args.frames)
     elif args.command == 'display':
         display(args.input, output=args.output, fps=args.fps, window=args.window)
+    elif args.command == 'loopback':
+        from kfe_loopback import run_loopback
+        run_loopback(tun=args.tun, device=args.device, packets=args.packets)
 
 
 if __name__ == '__main__':

--- a/kfe_loopback.py
+++ b/kfe_loopback.py
@@ -1,0 +1,166 @@
+"""Utilities for transmitting network packets via KFE frames.
+
+This module implements helper functions used in the loopback prototype.
+Packets are packed into a single KFE frame by prefixing them with their
+length. The frame is padded with zeroes to reach the fixed size expected by
+:mod:`kfe_codec`.
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+import time
+from typing import List
+
+from kfe_codec import FRAME_SIZE, WIDTH, HEIGHT, CHANNELS
+
+__all__ = ["packet_to_frame", "frame_to_packet", "run_loopback"]
+
+
+def packet_to_frame(packet: bytes) -> bytes:
+    """Return a byte sequence representing a KFE frame for ``packet``.
+
+    The frame layout is::
+
+        +---------+---------------------+
+        | length  | packet data [...]   |
+        +---------+---------------------+
+        | padding up to FRAME_SIZE      |
+        +-------------------------------+
+
+    Parameters
+    ----------
+    packet:
+        Raw network packet. Its size must not exceed ``FRAME_SIZE - 4``.
+
+    Returns
+    -------
+    bytes
+        A bytes object of exactly ``FRAME_SIZE`` bytes containing the packet.
+    """
+    if len(packet) > FRAME_SIZE - 4:
+        raise ValueError("Packet too large for a single frame")
+
+    header = struct.pack("<I", len(packet))
+    padding = FRAME_SIZE - 4 - len(packet)
+    return header + packet + bytes(padding)
+
+
+def frame_to_packet(frame: bytes) -> bytes:
+    """Extract a packet from a frame created by :func:`packet_to_frame`."""
+    if len(frame) != FRAME_SIZE:
+        raise ValueError("Invalid frame length")
+
+    length = struct.unpack("<I", frame[:4])[0]
+    if length > FRAME_SIZE - 4:
+        raise ValueError("Corrupted frame header")
+
+    return frame[4 : 4 + length]
+
+
+# Constants used by ``run_loopback`` to configure a TUN interface.
+TUNSETIFF = 0x400454ca
+IFF_TUN = 0x0001
+IFF_NO_PI = 0x1000
+
+
+def _open_tun(name: str) -> int:
+    """Create or attach to a TUN interface.
+
+    The caller must have sufficient privileges (usually root). The returned
+    file descriptor can be used for reading packets from the interface and
+    writing them back.
+    """
+    import fcntl
+
+    tun_fd = os.open("/dev/net/tun", os.O_RDWR)
+    ifr = struct.pack("16sH", name.encode(), IFF_TUN | IFF_NO_PI)
+    fcntl.ioctl(tun_fd, TUNSETIFF, ifr)
+    return tun_fd
+
+
+def run_loopback(
+    tun: str = "tun0",
+    device: int = 0,
+    packets: int = 100,
+    *,
+    os_read=os.read,
+    os_write=os.write,
+    os_close=os.close,
+) -> None:
+    """Simple loopback demo using a TUN interface and HDMI capture.
+
+    The function reads packets from ``tun``, converts them to frames using
+    :func:`packet_to_frame` and displays them with ``OpenCV``. The same frames
+    are captured back from ``device`` and decoded with :func:`frame_to_packet`.
+    Decoded packets are written back to the TUN interface.
+
+    Parameters
+    ----------
+    tun:
+        Name of the existing TUN interface (e.g. ``"tun0"``).
+    device:
+        Index of the capture device (the HDMI grabber in loopback setup).
+    packets:
+        Maximum number of packets to process. The function exits after this
+        many packets have been handled.
+    """
+
+    import cv2
+    import numpy as np
+
+    tun_fd = _open_tun(tun)
+
+    cap = cv2.VideoCapture(device)
+    if not cap.isOpened():
+        os_close(tun_fd)
+        raise RuntimeError(f"Unable to open capture device {device}")
+
+    try:
+        rtts: List[float] = []
+        bytes_total = 0
+        start_time = time.time()
+        processed = 0
+        while processed < packets:
+            send_ts = time.time()
+            data = os_read(tun_fd, 65535)
+            frame_bytes = packet_to_frame(data)
+
+            arr = (
+                np.frombuffer(frame_bytes, dtype="uint8")
+                .reshape((HEIGHT, WIDTH, CHANNELS))
+            )
+            arr = cv2.cvtColor(arr, cv2.COLOR_RGB2BGR)
+            cv2.imshow("kfe-loopback", arr)
+            cv2.waitKey(1)
+
+            ret, received = cap.read()
+            if not ret:
+                continue
+            received = cv2.resize(received, (WIDTH, HEIGHT))
+            received = cv2.cvtColor(received, cv2.COLOR_BGR2RGB)
+            packet = frame_to_packet(received.tobytes())
+            os_write(tun_fd, packet)
+            rtts.append(time.time() - send_ts)
+            bytes_total += len(packet)
+            processed += 1
+
+        elapsed = time.time() - start_time
+        if rtts:
+            rtt_min = min(rtts)
+            rtt_avg = sum(rtts) / len(rtts)
+            rtt_max = max(rtts)
+        else:
+            rtt_min = rtt_avg = rtt_max = 0.0
+        throughput = bytes_total / elapsed if elapsed > 0 else 0.0
+
+        print(
+            f"Processed: {processed} packets | "
+            f"RTT min/avg/max: {rtt_min:.4f}/{rtt_avg:.4f}/{rtt_max:.4f} s | "
+            f"Throughput: {throughput:.2f} B/s"
+        )
+    finally:
+        cap.release()
+        cv2.destroyAllWindows()
+        os_close(tun_fd)

--- a/tests/test_loopback.py
+++ b/tests/test_loopback.py
@@ -1,0 +1,98 @@
+import os
+import struct
+import sys
+import types
+
+import pytest
+
+from kfe_loopback import packet_to_frame, frame_to_packet, run_loopback
+from kfe_codec import FRAME_SIZE
+
+
+def test_packet_roundtrip():
+    data = b"hello packet"
+    frame = packet_to_frame(data)
+    assert len(frame) == FRAME_SIZE
+    assert frame_to_packet(frame) == data
+
+
+def test_packet_too_large():
+    data = bytes(FRAME_SIZE)
+    with pytest.raises(ValueError):
+        packet_to_frame(data)
+
+
+class DummyArray:
+    def __init__(self, buf=b""):
+        self.buf = buf
+
+    def tobytes(self):
+        return bytes(self.buf)
+
+    def reshape(self, shape):
+        return self
+
+
+def make_dummy_cv2(frame_bytes):
+    class DummyCap:
+        def __init__(self, device):
+            self.frame = frame_bytes
+            self.used = False
+
+        def isOpened(self):
+            return True
+
+        def read(self):
+            if self.used:
+                return False, None
+            self.used = True
+            return True, DummyArray(self.frame)
+
+        def release(self):
+            pass
+
+    dummy_cv2 = types.SimpleNamespace(
+        VideoCapture=lambda device: DummyCap(device),
+        resize=lambda frame, size: frame,
+        cvtColor=lambda frame, code: frame,
+        COLOR_BGR2RGB=1,
+        COLOR_RGB2BGR=2,
+        imshow=lambda *a, **k: None,
+        waitKey=lambda *a, **k: None,
+        destroyAllWindows=lambda: None,
+    )
+    return dummy_cv2
+
+
+def test_run_loopback(monkeypatch):
+    packet = b"net"
+    frame = packet_to_frame(packet)
+
+    written = []
+
+    def fake_read(fd, n):
+        return packet
+
+    def fake_write(fd, data):
+        written.append(data)
+
+    def fake_close(fd):
+        pass
+
+    dummy_cv2 = make_dummy_cv2(frame)
+    dummy_np = types.SimpleNamespace(frombuffer=lambda buf, dtype: DummyArray(buf))
+
+    monkeypatch.setitem(sys.modules, "cv2", dummy_cv2)
+    monkeypatch.setitem(sys.modules, "numpy", dummy_np)
+    monkeypatch.setattr("kfe_loopback._open_tun", lambda name: 1)
+
+    run_loopback(
+        tun="tun0",
+        device=0,
+        packets=1,
+        os_read=fake_read,
+        os_write=fake_write,
+        os_close=fake_close,
+    )
+
+    assert written == [packet]


### PR DESCRIPTION
## Summary
- expose loopback demo via `kfe_codec.py`
- collect RTT and throughput stats in `run_loopback`
- document how to set up a TUN interface and use the new command
- add unit test covering the loopback routine

## Testing
- `pytest -q`