### PR TITLE
Add RTT metrics and periodic reporting

### DIFF
--- a/kfe_codec.py
+++ b/kfe_codec.py
@@ -200,6 +200,7 @@ def main(argv=None):
     loop.add_argument('--tun', default='tun0', help='TUN interface name')
     loop.add_argument('--device', type=int, default=0, help='Capture device ID')
     loop.add_argument('--packets', type=int, default=100, help='Number of packets to process')
+    loop.add_argument('--periodic', action='store_true', help='Print metrics after each packet')
 
     parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose logging')
 
@@ -216,7 +217,12 @@ def main(argv=None):
         display(args.input, output=args.output, fps=args.fps, window=args.window)
     elif args.command == 'loopback':
         from kfe_loopback import run_loopback
-        run_loopback(tun=args.tun, device=args.device, packets=args.packets)
+        run_loopback(
+            tun=args.tun,
+            device=args.device,
+            packets=args.packets,
+            periodic=args.periodic,
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_loopback.py
+++ b/tests/test_loopback.py
@@ -35,19 +35,20 @@ class DummyArray:
         return self
 
 
-def make_dummy_cv2(frame_bytes):
+def make_dummy_cv2(frame_bytes, *, frames=1):
     class DummyCap:
         def __init__(self, device):
             self.frame = frame_bytes
-            self.used = False
+            self.frames = frames
+            self.count = 0
 
         def isOpened(self):
             return True
 
         def read(self):
-            if self.used:
+            if self.count >= self.frames:
                 return False, None
-            self.used = True
+            self.count += 1
             return True, DummyArray(self.frame)
 
         def release(self):
@@ -81,7 +82,7 @@ def test_run_loopback(monkeypatch):
     def fake_close(fd):
         pass
 
-    dummy_cv2 = make_dummy_cv2(frame)
+    dummy_cv2 = make_dummy_cv2(frame, frames=2)
     dummy_np = types.SimpleNamespace(frombuffer=lambda buf, dtype: DummyArray(buf))
 
     monkeypatch.setitem(sys.modules, "cv2", dummy_cv2)
@@ -98,4 +99,89 @@ def test_run_loopback(monkeypatch):
     )
 
     assert written == [packet]
+
+
+def test_run_loopback_metrics(monkeypatch, capsys):
+    packet = b"ab"
+    frame = packet_to_frame(packet)
+
+    written = []
+
+    def fake_read(fd, n):
+        return packet
+
+    def fake_write(fd, data):
+        written.append(data)
+
+    def fake_close(fd):
+        pass
+
+    dummy_cv2 = make_dummy_cv2(frame, frames=2)
+    dummy_np = types.SimpleNamespace(frombuffer=lambda buf, dtype: DummyArray(buf))
+
+    monkeypatch.setitem(sys.modules, "cv2", dummy_cv2)
+    monkeypatch.setitem(sys.modules, "numpy", dummy_np)
+    monkeypatch.setattr("kfe_loopback._open_tun", lambda name: 1)
+
+    times = [0.0, 1.0, 1.2, 2.0, 2.5, 3.0]
+    def fake_monotonic():
+        return times.pop(0) if times else 3.0
+    monkeypatch.setattr("kfe_loopback.time.monotonic", fake_monotonic)
+
+    run_loopback(
+        tun="tun0",
+        device=0,
+        packets=2,
+        os_read=fake_read,
+        os_write=fake_write,
+        os_close=fake_close,
+        periodic=False,
+    )
+
+    out = capsys.readouterr().out.strip().splitlines()[-1]
+    assert written == [packet, packet]
+    assert "Processed: 2 packets" in out
+    assert "RTT min/avg/max: 0.2000/0.3500/0.5000 s" in out
+    assert "Throughput: 1.33 B/s" in out
+
+
+def test_run_loopback_periodic(monkeypatch, capsys):
+    packet = b"x"
+    frame = packet_to_frame(packet)
+
+    def fake_read(fd, n):
+        return packet
+
+    def fake_write(fd, data):
+        pass
+
+    def fake_close(fd):
+        pass
+
+    dummy_cv2 = make_dummy_cv2(frame)
+    dummy_np = types.SimpleNamespace(frombuffer=lambda buf, dtype: DummyArray(buf))
+
+    monkeypatch.setitem(sys.modules, "cv2", dummy_cv2)
+    monkeypatch.setitem(sys.modules, "numpy", dummy_np)
+    monkeypatch.setattr("kfe_loopback._open_tun", lambda name: 1)
+
+    times = [0.0, 1.0, 1.1, 2.0, 2.1, 3.0]
+    def fake_monotonic():
+        return times.pop(0) if times else 3.0
+    monkeypatch.setattr("kfe_loopback.time.monotonic", fake_monotonic)
+
+    run_loopback(
+        tun="tun0",
+        device=0,
+        packets=2,
+        os_read=fake_read,
+        os_write=fake_write,
+        os_close=fake_close,
+        periodic=True,
+    )
+
+    out_lines = capsys.readouterr().out.strip().splitlines()
+    assert len(out_lines) == 3  # two periodic + final
+    assert "Processed: 1 packets" in out_lines[0]
+    assert "Processed: 2 packets" in out_lines[-1]
 


### PR DESCRIPTION
## Summary
- track send/receive time with `time.monotonic`
- optionally print stats after each packet using `--periodic`
- compute min/avg/max RTT and throughput
- test metric calculation with mocked time

## Testing
- `pytest -q`